### PR TITLE
Rename 'spy' to 'stub' within automock proper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,29 +12,31 @@ A Node.js automatic mocking tool.
 
 ## Overview
 
-There are some really good unit testing tools like `proxyquire` that can help isolate your code from external dependencies.  The only downside is that you have to implement any mocked dependencies yourself.  Further, it's very easy to use a partially-mocked implementation which breaks when the dependency itself changes.
+There are some really good unit testing tools like `proxyquire` that can help
+isolate your code from external dependencies.  The only downside is that you have
+to implement any mocked dependencies yourself.  Further, it's very easy to use a
+partially-mocked implementation which breaks when the dependency itself changes.
 
-`automock` attempts to solve these problems by automatically creating lookalike exports with all functionality stubbed out.
+`automock` attempts to solve these problems by automatically creating lookalike
+exports with all functionality stubbed out.
 
 
 ## Usage
 
-You should be able to use `automock` where you use `proxyquire`, but without needing
-to pre-define your stubs:
+You should be able to use `automock.require()` anywhere you would use `proxyquire()`,
+but without necessarily needing to pre-define your stubs:
 
 ```javascript
 var automock = require('automock');
-automock.setSpyCreator(jasmine.createSpy);
+automock.setStubCreator(jasmine.createSpy);
 
 var myModule = automock.require('../lib/my-module');
 
-// Write your tests!
-
 describe('my module', function() {
-    
+
     it('doIt calls util.format once', function() {
         myModule.doIt();
-        expect(myModule.__stubs__.util.format).toHaveBeenCalled();
+        expect(myModule.__stubs__.util.format.calls.count()).toBe(1);
     });
 
 });
@@ -45,94 +47,137 @@ dependencies to pass through, you can do so:
 
 ```javascript
 var automock = require('automock');
-automock.setSpyCreator(jasmine.createSpy);
+automock.setStubCreator(jasmine.createSpy);
 
-var cryptoMock = /* ... */ ;
+var cryptoMock = /* ... hand-crafted mock of Node's 'crypto' module ... */ ;
 
 var myModule = automock.require('../lib/my-module', {
     stubs: {
         // If you need manually-created stubs, list them here, using the
-        // same format at proxyquire.
+        // same format as `proxyquire`.
         'crypto': cryptoMock,
     },
     passThru: [
-        // List dependencies you *don't* want mocked here.
+        // List any dependencies you *don't* want mocked here.
         'util.inspect',
     ],
+});
+```
+
+In this case, `crypto` is replaced by your hand-crafted stub, the actual
+`util.inspect` module is left unmocked, and any other dependencies are automatically
+stubbed out (using `jasmine.createSpy` in this example).
+
+Finally, if you want to customize the automatically created stubs you can do so
+in the `stubCreator` function:
+
+```javascript
+var automock = require('automock');
+automock.setStubCreator(spyCreator);
+
+function spyCreator(name) {
+    // Stubs are named for their dot-notation object path, starting with the
+    // module name.  Get/Set properties have "__get__" or "__set__" as the
+    // last part of their name.
+    var spy;
+
+    switch (name) {
+        case 'some-dependency.someFunction':
+            spy = jasmine.createSpy(name).and.callFake(function() {
+                // do something special!
+            });
+            break;
+
+        case 'some-dependency.someProperty.__get__':
+            spy = jasmine.createSpy(name).and.returnValue(42);
+            break;
+
+        default:
+            spy = jasmine.createSpy(name);
+    }
+
+    return spy;
+}
+
+// Assume `my-module` has a `require('some-dependency')` statement!
+var myModule = automock.require('../lib/my-module');
+
+describe('my module', function() {
+
+    it('calls someFunction', function() {
+        myModule.callsSomeFunction();
+        expect(myModule.__stubs__['some-dependency'].someFunction.calls.count()).toBe(1);
+    });
+
+    it('gets someProperty', function() {
+        var prop = myModule.getsSomeProperty();
+        expect(prop).toBe(42);
+    });
+
+});
+```
+
+Or, if your stubs can handle modification after-the-fact,
+as jasmine's do, you can modify them _after_ they are created, since they are
+passed back via the required module's `__stubs__` property:
+
+```javascript
+var automock = require('automock');
+automock.setStubCreator(jasmine.createSpy);
+
+// Assume `my-module` has a `require('some-dependency')` statement!
+var myModule = automock.require('../lib/my-module');
+
+// Modify the stub/spy behavior after they're created...
+myModule.__stubs__['some-dependency'].someFunction.and.callFake(function() {
+    // do something special!
+});
+
+myModule.__stubs__['some-dependency'].someProperty.__get__.and.returnValue(42);
+
+describe('my module', function() {
+
+    it('calls someFunction', function() {
+        myModule.callsSomeFunction();
+        expect(myModule.__stubs__['some-dependency'].someFunction.calls.count()).toBe(1);
+    });
+
+    it('gets someProperty', function() {
+        var prop = myModule.getsSomeProperty();
+        expect(prop).toBe(42);
+    });
+
 });
 ```
 
 
 ## Low-level usage
 
-(Further details to-be-written...)
+Occasionally, you may want to create a "just-in-time" mock of a particular
+dependency or object.  You can do this using the `automock.mockModule()` and
+`automock.mockValue()` functions.
 
 ```javascript
 var automock = require('automock');
 
-var someDependency = automock.mock('some-dependency');
+var someDependency = automock.mockModule('some-dependency');
+// `someDependency` now looks just like the normal exports from
+// `require('some-dependency')` would, but any functions are stubbed out.
+// This is effectively what you get for `some-dependency` when it's a
+// dependency inside of a module you've called `automock.require()` on.
 
-// `someDependency` should look just like the normal exports
-// from `require('some-dependency')` would, but calling any
-// functions won't have any effect.
-```
+var someDynamicallyCreatedObject = /* ... something returned from an API ... */ ;
 
-#### Customizing stub/spy creation...
-
-```javascript
-var automock = require('automock');
-automock.setSpyCreator(jasmine.createSpy);
-
-var someDependency = automock.mock('some-dependency');
-
-someDependency.someFunction();
-expect(someDependency.someFunction.calls.count).toBe(1);
-```
-
-If you want to control stub/spy creation on a mock-by-mock basis, you can also pass a _spyCreator_ function as the second parameter to the `mock()` call, and it will override the default creator passed to the `automock.setSpyCreator()` function.
-
-
-```javascript
-var anotherDependency = automock.mock('another-dependency', anotherSpyCreator);
-```
-
-For more advanced behavior, you can customize the spy on a case-by-case basis:
-
-```javascript
-var automock = require('automock');
-automock.setSpyCreator(spyCreator);
-
-function spyCreator(name) {
-    // Spies are named for their dot-notation object path,
-    // starting with the module name.  Get/Set properties
-    // have "__get__" or "__set__" as the last part of their
-    // name.
-
-    var spy = jasmine.createSpy(name);
-
-    switch (name) {
-        case 'some-dependency.someFunction':
-            spy.andCallFake(function() {
-                // do something special!
-            });
-            break;
-
-        case 'some-dependency.someProperty.__get__':
-            spy.andReturn(42);
-            break;
-    }
-
-    return spy;
-}
-
-var someDependency = automock.mock('some-dependency');
-
-someDependency.someFunction();
-expect(someDependency.someFunction.calls.count).toBe(1);
-expect(someDependency.someProperty).toBe(42);
+var mockedObject = automock.mockValue(someDynamicallyCreatedObject);
+// `mockedObject` now looks just like `someDynamicallyCreatedObject`, but any
+// function properties (even nested ones!) are stubbed out.
 ```
 
 
 ## Caveats
 
-In order to ensure it creates look-alike exports, `automock` has to _actually_ load the dependency it's attempting to mock.  If the act of compiling/loading the module has side-effects, those will happen!  With any luck, though, those should be rare occurrences; modules really shouldn't be written that way in general, for exactly that reason.
+In order to ensure it creates look-alike exports, `automock` has to _actually_
+load the dependency it's attempting to mock.  If the act of compiling/loading the
+module has side-effects, those will happen!  With any luck, though, those should
+be rare occurrences; modules really shouldn't be written that way in general, for
+exactly that reason.

--- a/lib/automock.js
+++ b/lib/automock.js
@@ -10,11 +10,10 @@ var Module = require('module');
 var ProxyquireWrapper = require('./proxyquire-wrapper');
 
 
-function stubSpyCreator(name) {
-    // console.log(_.sprintf('<creating spy for "%s()">', name));
-    return function spy() {
+function simpleStubCreator(name) {
+    return function stub() {
         // TODO: report arguments in a sane/safe way?
-        console.log(_.sprintf('<spy for "%s()">', name));
+        console.log(_.sprintf('<stub for "%s()">', name));
     };
 }
 
@@ -22,14 +21,14 @@ function stubSpyCreator(name) {
 function AutoMock(parent) {
     this._parent = parent;
     this._proxyquire = new ProxyquireWrapper(parent, this);
-    this.setSpyCreator();
+    this.setStubCreator();
 }
 
-AutoMock.prototype.setSpyCreator = function (spyCreator) {
-    this.defaultSpyCreator = spyCreator || stubSpyCreator;
+AutoMock.prototype.setStubCreator = function (stubCreator) {
+    this.defaultStubCreator = stubCreator || simpleStubCreator;
 };
 
-AutoMock.prototype.mock = function (moduleName, params) {
+AutoMock.prototype.mockModule = function (moduleName, params) {
     var context = this._createMockingContext(params);
 
     var orig = Module._load(moduleName, this._parent);
@@ -44,7 +43,7 @@ AutoMock.prototype._createMockingContext = function (params) {
     params = params || {};
 
     return {
-        spyCreator: params.spyCreator || this.defaultSpyCreator,
+        stubCreator: params.stubCreator || this.defaultStubCreator,
 
         passThru: params.passThru || [],
 
@@ -71,7 +70,7 @@ AutoMock.prototype._mockValue = function (name, orig, context) {
             return context.mocks[index];
         }
         if (_.isFunction(orig)) {
-            mock = context.spyCreator(name);
+            mock = context.stubCreator(name);
             ignoredProperties = functionIgnored;
         } else if (_.isArray(orig)) {
             mock = [];

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An automatic mock creator",
   "main": "./index.js",
   "scripts": {
-    "test": "istanbul cover --include-all-sources jasmine --captureExceptions",
+    "test": "istanbul cover -x **/spec/** --include-all-sources jasmine --captureExceptions",
     "test-coverage": "npm run-script test && cat ./coverage/coverage.json | codecov"
   },
   "keywords": [

--- a/spec/unit/indexSpec.js
+++ b/spec/unit/indexSpec.js
@@ -1,0 +1,26 @@
+'use strict';
+
+var proxyquire = require('proxyquire');
+var MockAutoMock = jasmine.createSpy('constructor');
+
+
+describe('index', function() {
+    var automock;
+
+    beforeEach(function() {
+        MockAutoMock.calls.reset();
+
+        automock = proxyquire('../../index', {
+            './lib/automock': MockAutoMock,
+        });
+    });
+
+    it('creates an automock object', function() {
+        expect(MockAutoMock.calls.count()).toBe(1);
+    });
+
+    it('passes the requiring module as the parent', function() {
+        expect(MockAutoMock.calls.argsFor(0)[0].id).toEqual(module.id);
+    });
+
+});


### PR DESCRIPTION
Clean up README.
Expand unit test coverage.