### PR TITLE
Allow passThru for entire modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ var myModule = automock.require('../lib/my-module', {
     passThru: [
         // List any dependencies you *don't* want mocked here.
         'util.inspect',
+        'lodash',
     ],
 });
 ```
 
-In this case, `crypto` is replaced by your hand-crafted stub, the actual
-`util.inspect` module is left unmocked, and any other dependencies are automatically
-stubbed out (using `jasmine.createSpy` in this example).
+In this case, `crypto` is replaced by your hand-crafted stub, the actual `lodash`
+module and `util.inspect` property are left unmocked, and any other dependencies
+are automatically stubbed out (using `jasmine.createSpy` in this example).
 
 Or, if your stubs can handle modification after-the-fact,
 as Jasmine's do, you can modify them _after_ they are created, since they are

--- a/lib/proxyquire-wrapper.js
+++ b/lib/proxyquire-wrapper.js
@@ -71,7 +71,7 @@ ProxyquireWrapper.prototype._require = function(callingModule, stubs, path) {
     //   * it doesn't have a manual stub in place
     //   * it hasn't been excluded from mocking
     //   * it is being required directly by the file under test // REVIEW: true?
-    if (callingModule.filename === this._primaryModuleFile) {
+    if (callingModule.filename === this._primaryModuleFile && !_.contains(this._params.passThru, path)) {
         if (!this._stubs.hasOwnProperty(path)) {
             var localParams = {
                 name: path,

--- a/spec/unit/proxyquire-wrapperSpec.js
+++ b/spec/unit/proxyquire-wrapperSpec.js
@@ -11,7 +11,7 @@ var proxyquire = require('proxyquire');
 
 
 var MockModule = {
-    _resolveFilename: jasmine.createSpy('_resolveFilename').and.returnValue('dummy'), 
+    _resolveFilename: jasmine.createSpy('_resolveFilename').and.returnValue('dummy'),
 };
 
 // How meta can we get?  We're using proxyquire to stub out proxyquire in the
@@ -39,7 +39,7 @@ var ProxyquireWrapper = proxyquire('../../lib/proxyquire-wrapper', stubs);
 
 describe('proxyquire-wrapper', function() {
     var wrapper;
-    
+
     beforeEach(function() {
         MockProxyquire.calls.reset();
         MockProxyquire.prototype.load.calls.reset();
@@ -55,7 +55,7 @@ describe('proxyquire-wrapper', function() {
 
     describe('load', function() {
         var dummy;
-        
+
         beforeEach(function() {
             dummy = wrapper.load('./dummy', {}, {});
         });
@@ -73,7 +73,7 @@ describe('proxyquire-wrapper', function() {
         });
 
     });
-    
+
     describe('_require', function() {
         function callWrapperRequire() {
             wrapper._require({ filename: 'dummy' }, {}, 'dummy');
@@ -84,25 +84,31 @@ describe('proxyquire-wrapper', function() {
             wrapper._stubs = {};
             wrapper._params = {};
             wrapper._primaryModuleFile = 'dummy';
-            
+
             mockAutomock.mockValue.calls.reset();
         });
-        
+
         it('calls through to Proxyquire\'s _require', function() {
             var result = callWrapperRequire();
-            expect(MockProxyquire.prototype._require.calls.count()).toBe(1);            
+            expect(MockProxyquire.prototype._require.calls.count()).toBe(1);
         });
-                
+
         it('does not mock for dependecies of a non-primary module', function() {
             wrapper._primaryModuleFile = 'not-dummy';
             var result = callWrapperRequire();
             expect(mockAutomock.mockValue.calls.count()).toBe(0);
         });
-        
+
         it('does mock for dependecies of the primary module', function() {
             var result = callWrapperRequire();
             expect(mockAutomock.mockValue.calls.count()).toBe(1);
         });
+
+        it('does not mock for dependencies in passThru', function() {
+            wrapper._params = {passThru: ['dummy']};
+            var result = callWrapperRequire();
+            expect(mockAutomock.mockValue.calls.count()).toBe(0);
+        })
     });
 
 });


### PR DESCRIPTION
This patch allows entire modules (like `lodash` or `react`) to be left unmocked. It seemed that previously you could only passThru an individual property on an import (such as `util.inspect`).

It's implemented in `lib/proxyquire-wrapper` to avoid it showing at all in the `__stubs__` property. The work could be moved into `lib/automock` if you still want to expose the unmocked version (e.g. for replacement at runtime).

Thanks for a great module!