### PR TITLE
Swapped from _.sprintf to sprintf-js

### DIFF
--- a/lib/automock.js
+++ b/lib/automock.js
@@ -2,6 +2,7 @@
 
 var _ = require('underscore');
 _.mixin(require('underscore.string').exports());
+var sprintf = require('sprintf-js').sprintf;
 
 var path = require('path');
 var util = require('util');
@@ -13,7 +14,7 @@ var ProxyquireWrapper = require('./proxyquire-wrapper');
 function simpleStubCreator(name) {
     return function stub() {
         // TODO: report arguments in a sane/safe way?
-        console.log(_.sprintf('<stub for "%s()">', name));
+        console.log(sprintf('<stub for "%s()">', name));
     };
 }
 
@@ -132,7 +133,7 @@ AutoMock.prototype._mockProperties = function (name, orig, mock, ignoredProperti
 
         var desc = Object.getOwnPropertyDescriptor(orig, key);
         var mockDesc;
-        var fullName = _.sprintf("%s.%s", name, key);
+        var fullName = sprintf("%s.%s", name, key);
 
         if (_.contains(context.passThru, fullName)) {
             mockDesc = desc;
@@ -148,11 +149,11 @@ AutoMock.prototype._mockProperties = function (name, orig, mock, ignoredProperti
             }
 
             if (desc.get) {
-                mockDesc.get = self._mockValue(_.sprintf("%s.%s", fullName, '__get__'), desc.get, context);
+                mockDesc.get = self._mockValue(sprintf("%s.%s", fullName, '__get__'), desc.get, context);
             }
 
             if (desc.set) {
-                mockDesc.set = self._mockValue(_.sprintf("%s.%s", fullName, '__set__'), desc.set, context);
+                mockDesc.set = self._mockValue(sprintf("%s.%s", fullName, '__set__'), desc.set, context);
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "homepage": "https://github.com/HBOCodeLabs/automock#readme",
   "dependencies": {
     "proxyquire": "^1.7.2",
+    "sprintf-js": "^1.0.3",
     "underscore": "^1.8.3",
     "underscore.string": "^3.2.2"
   },

--- a/spec/unit/automockSpec.js
+++ b/spec/unit/automockSpec.js
@@ -2,6 +2,7 @@
 
 var _ = require('underscore');
 _.mixin(require('underscore.string').exports());
+var sprintf = require('sprintf-js').sprintf;
 
 var proxyquire = require('proxyquire');
 
@@ -219,7 +220,7 @@ describe('automock', function() {
     ];
 
     standardModules.forEach(function(moduleName) {
-        it(_.sprintf('properly mocks %s', moduleName), function() {
+        it(sprintf('properly mocks %s', moduleName), function() {
             checkModuleMocking(moduleName);
         });
 


### PR DESCRIPTION
Upgraded from `_.sprintf` to `sprintf-js` to remove deprecation warning.